### PR TITLE
change overlay z-index

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,7 +30,7 @@
             overlay.style.position = "absolute";
             overlay.style.top = overlay.style.left = "0";
             overlay.style.width = overlay.style.height = "100%";
-            overlay.style.zIndex = "10";
+            overlay.style.zIndex = "0";
             overlay.style.opacity = opacity; // Apply the opacity here
             // Overlay is appended as a child of the original image's parent element (the thing we did query select), making it go on top
             thumbnail.parentElement.appendChild(overlay);


### PR DESCRIPTION
I changed the z-index so that the overlay doesn't cover the duration of the video, and it also disappears and doesn't interfere with preview when you hover over it. I tested it in Chromium-like browsers.
![ezgif-2-7a4c0bdbfa](https://github.com/user-attachments/assets/c142dd29-29dc-4834-8f12-68034f87ab21)
